### PR TITLE
Enable social previews for blog posts

### DIFF
--- a/posts/2020-06-02-snacs.html
+++ b/posts/2020-06-02-snacs.html
@@ -4,12 +4,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Aryaman Arora</title>
-  <meta name="description" content="Aryaman Arora: NLP Researcher">
-  <meta property="og:title" content="Aryaman Arora">
-  <meta property="og:description" content="NLP Researcher">
-  <link rel="canonical" href="https://aryamanarora.github.io/">
-  <meta name="twitter:card" content="summary">
+  <title>Hindi adpositions - Aryaman Arora</title>
+  <meta name="description" content="Blog post by Aryaman Arora">
+  <meta property="og:title" content="Hindi adpositions">
+  <meta property="og:type" content="article">
+<meta property="og:description" content="Blog post by Aryaman Arora">
+  <meta property="og:url" content="https://aryaman.io/posts/2020-06-02-snacs.html">
+  <meta property="og:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <meta name="twitter:title" content="Hindi adpositions">
+  <meta name="twitter:description" content="Blog post by Aryaman Arora">
+  <meta name="twitter:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <link rel="canonical" href="https://aryaman.io/posts/2020-06-02-snacs.html">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@aryaman2020">
   <link rel="stylesheet" href="/main.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leipzig@latest/dist/leipzig.min.css">

--- a/posts/2020-07-10-acl.html
+++ b/posts/2020-07-10-acl.html
@@ -4,12 +4,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Aryaman Arora</title>
-  <meta name="description" content="Aryaman Arora: NLP Researcher">
-  <meta property="og:title" content="Aryaman Arora">
-  <meta property="og:description" content="NLP Researcher">
-  <link rel="canonical" href="https://aryamanarora.github.io/">
-  <meta name="twitter:card" content="summary">
+  <title>ACL 2020 - Aryaman Arora</title>
+  <meta name="description" content="Blog post by Aryaman Arora">
+  <meta property="og:title" content="ACL 2020">
+  <meta property="og:type" content="article">
+<meta property="og:description" content="Blog post by Aryaman Arora">
+  <meta property="og:url" content="https://aryaman.io/posts/2020-07-10-acl.html">
+  <meta property="og:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <meta name="twitter:title" content="ACL 2020">
+  <meta name="twitter:description" content="Blog post by Aryaman Arora">
+  <meta name="twitter:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <link rel="canonical" href="https://aryaman.io/posts/2020-07-10-acl.html">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@aryaman2020">
   <link rel="stylesheet" href="/main.css">
 </head>

--- a/posts/2020-11-18-emnlp.html
+++ b/posts/2020-11-18-emnlp.html
@@ -4,12 +4,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Aryaman Arora</title>
-  <meta name="description" content="Aryaman Arora: NLP Researcher">
-  <meta property="og:title" content="Aryaman Arora">
-  <meta property="og:description" content="NLP Researcher">
-  <link rel="canonical" href="https://aryamanarora.github.io/">
-  <meta name="twitter:card" content="summary">
+  <title>EMNLP 2020 - Aryaman Arora</title>
+  <meta name="description" content="Blog post by Aryaman Arora">
+  <meta property="og:title" content="EMNLP 2020">
+  <meta property="og:type" content="article">
+<meta property="og:description" content="Blog post by Aryaman Arora">
+  <meta property="og:url" content="https://aryaman.io/posts/2020-11-18-emnlp.html">
+  <meta property="og:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <meta name="twitter:title" content="EMNLP 2020">
+  <meta name="twitter:description" content="Blog post by Aryaman Arora">
+  <meta name="twitter:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <link rel="canonical" href="https://aryaman.io/posts/2020-11-18-emnlp.html">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@aryaman2020">
   <link rel="stylesheet" href="/main.css">
 </head>

--- a/posts/2020-12-12-why-linguistics.html
+++ b/posts/2020-12-12-why-linguistics.html
@@ -4,12 +4,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Aryaman Arora</title>
-  <meta name="description" content="Aryaman Arora: NLP Researcher">
-  <meta property="og:title" content="Aryaman Arora">
-  <meta property="og:description" content="NLP Researcher">
-  <link rel="canonical" href="https://aryamanarora.github.io/">
-  <meta name="twitter:card" content="summary">
+  <title>Why linguistics? - Aryaman Arora</title>
+  <meta name="description" content="Blog post by Aryaman Arora">
+  <meta property="og:title" content="Why linguistics?">
+  <meta property="og:type" content="article">
+<meta property="og:description" content="Blog post by Aryaman Arora">
+  <meta property="og:url" content="https://aryaman.io/posts/2020-12-12-why-linguistics.html">
+  <meta property="og:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <meta name="twitter:title" content="Why linguistics?">
+  <meta name="twitter:description" content="Blog post by Aryaman Arora">
+  <meta name="twitter:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <link rel="canonical" href="https://aryaman.io/posts/2020-12-12-why-linguistics.html">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@aryaman2020">
   <link rel="stylesheet" href="/main.css">
 </head>

--- a/posts/2020-12-14-nia-conservatisms.html
+++ b/posts/2020-12-14-nia-conservatisms.html
@@ -4,12 +4,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Aryaman Arora</title>
-  <meta name="description" content="Aryaman Arora: NLP Researcher">
-  <meta property="og:title" content="Aryaman Arora">
-  <meta property="og:description" content="NLP Researcher">
-  <link rel="canonical" href="https://aryamanarora.github.io/">
-  <meta name="twitter:card" content="summary">
+  <title>New Indo-Aryan Conservatisms - Aryaman Arora</title>
+  <meta name="description" content="Blog post by Aryaman Arora">
+  <meta property="og:title" content="New Indo-Aryan Conservatisms">
+  <meta property="og:type" content="article">
+<meta property="og:description" content="Blog post by Aryaman Arora">
+  <meta property="og:url" content="https://aryaman.io/posts/2020-12-14-nia-conservatisms.html">
+  <meta property="og:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <meta name="twitter:title" content="New Indo-Aryan Conservatisms">
+  <meta name="twitter:description" content="Blog post by Aryaman Arora">
+  <meta name="twitter:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <link rel="canonical" href="https://aryaman.io/posts/2020-12-14-nia-conservatisms.html">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@aryaman2020">
   <link rel="stylesheet" href="/main.css">
 </head>

--- a/posts/2021-02-10-bhasacitra.html
+++ b/posts/2021-02-10-bhasacitra.html
@@ -4,12 +4,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Aryaman Arora</title>
-  <meta name="description" content="Aryaman Arora: NLP Researcher">
-  <meta property="og:title" content="Aryaman Arora">
-  <meta property="og:description" content="NLP Researcher">
-  <link rel="canonical" href="https://aryamanarora.github.io/">
-  <meta name="twitter:card" content="summary">
+  <title>Bhāṣācitra - Aryaman Arora</title>
+  <meta name="description" content="Blog post by Aryaman Arora">
+  <meta property="og:title" content="Bhāṣācitra">
+  <meta property="og:type" content="article">
+<meta property="og:description" content="Blog post by Aryaman Arora">
+  <meta property="og:url" content="https://aryaman.io/posts/2021-02-10-bhasacitra.html">
+  <meta property="og:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <meta name="twitter:title" content="Bhāṣācitra">
+  <meta name="twitter:description" content="Blog post by Aryaman Arora">
+  <meta name="twitter:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <link rel="canonical" href="https://aryaman.io/posts/2021-02-10-bhasacitra.html">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@aryaman2020">
   <link rel="stylesheet" href="/main.css">
 </head>

--- a/posts/2021-03-08-hindi-is-not-sanskrit.html
+++ b/posts/2021-03-08-hindi-is-not-sanskrit.html
@@ -4,12 +4,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Aryaman Arora</title>
-  <meta name="description" content="Aryaman Arora: NLP Researcher">
-  <meta property="og:title" content="Aryaman Arora">
-  <meta property="og:description" content="NLP Researcher">
-  <link rel="canonical" href="https://aryamanarora.github.io/">
-  <meta name="twitter:card" content="summary">
+  <title>Hindi is not Sanskrit: Phonetics and Phonology - Aryaman Arora</title>
+  <meta name="description" content="Blog post by Aryaman Arora">
+  <meta property="og:title" content="Hindi is not Sanskrit: Phonetics and Phonology">
+  <meta property="og:type" content="article">
+<meta property="og:description" content="Blog post by Aryaman Arora">
+  <meta property="og:url" content="https://aryaman.io/posts/2021-03-08-hindi-is-not-sanskrit.html">
+  <meta property="og:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <meta name="twitter:title" content="Hindi is not Sanskrit: Phonetics and Phonology">
+  <meta name="twitter:description" content="Blog post by Aryaman Arora">
+  <meta name="twitter:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <link rel="canonical" href="https://aryaman.io/posts/2021-03-08-hindi-is-not-sanskrit.html">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@aryaman2020">
   <link rel="stylesheet" href="/main.css">
 </head>

--- a/posts/2021-05-13-greater-magadha.html
+++ b/posts/2021-05-13-greater-magadha.html
@@ -4,12 +4,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Aryaman Arora</title>
-  <meta name="description" content="Aryaman Arora: NLP Researcher">
-  <meta property="og:title" content="Aryaman Arora">
-  <meta property="og:description" content="NLP Researcher">
-  <link rel="canonical" href="https://aryamanarora.github.io/">
-  <meta name="twitter:card" content="summary">
+  <title>Greater Magadha - Aryaman Arora</title>
+  <meta name="description" content="Blog post by Aryaman Arora">
+  <meta property="og:title" content="Greater Magadha">
+  <meta property="og:type" content="article">
+<meta property="og:description" content="Blog post by Aryaman Arora">
+  <meta property="og:url" content="https://aryaman.io/posts/2021-05-13-greater-magadha.html">
+  <meta property="og:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <meta name="twitter:title" content="Greater Magadha">
+  <meta name="twitter:description" content="Blog post by Aryaman Arora">
+  <meta name="twitter:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <link rel="canonical" href="https://aryaman.io/posts/2021-05-13-greater-magadha.html">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@aryaman2020">
   <link rel="stylesheet" href="/main.css">
 </head>

--- a/posts/2021-09-07-sikk.html
+++ b/posts/2021-09-07-sikk.html
@@ -4,12 +4,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Aryaman Arora</title>
-  <meta name="description" content="Aryaman Arora: NLP Researcher">
-  <meta property="og:title" content="Aryaman Arora">
-  <meta property="og:description" content="NLP Researcher">
-  <link rel="canonical" href="https://aryamanarora.github.io/">
-  <meta name="twitter:card" content="summary">
+  <title> - Aryaman Arora</title>
+  <meta name="description" content="Blog post by Aryaman Arora">
+  <meta property="og:title" content="">
+  <meta property="og:type" content="article">
+<meta property="og:description" content="Blog post by Aryaman Arora">
+  <meta property="og:url" content="https://aryaman.io/posts/2021-09-07-sikk.html">
+  <meta property="og:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <meta name="twitter:title" content="">
+  <meta name="twitter:description" content="Blog post by Aryaman Arora">
+  <meta name="twitter:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <link rel="canonical" href="https://aryaman.io/posts/2021-09-07-sikk.html">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@aryaman2020">
   <link rel="stylesheet" href="/main.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leipzig@latest/dist/leipzig.min.css">

--- a/posts/2022-01-12-reflexive.html
+++ b/posts/2022-01-12-reflexive.html
@@ -4,12 +4,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Aryaman Arora</title>
-  <meta name="description" content="Aryaman Arora: NLP Researcher">
-  <meta property="og:title" content="Aryaman Arora">
-  <meta property="og:description" content="NLP Researcher">
-  <link rel="canonical" href="https://aryamanarora.github.io/">
-  <meta name="twitter:card" content="summary">
+  <title>Reflexive causatives in Hindi - Aryaman Arora</title>
+  <meta name="description" content="Blog post by Aryaman Arora">
+  <meta property="og:title" content="Reflexive causatives in Hindi">
+  <meta property="og:type" content="article">
+<meta property="og:description" content="Blog post by Aryaman Arora">
+  <meta property="og:url" content="https://aryaman.io/posts/2022-01-12-reflexive.html">
+  <meta property="og:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <meta name="twitter:title" content="Reflexive causatives in Hindi">
+  <meta name="twitter:description" content="Blog post by Aryaman Arora">
+  <meta name="twitter:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <link rel="canonical" href="https://aryaman.io/posts/2022-01-12-reflexive.html">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@aryaman2020">
   <link rel="stylesheet" href="/main.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leipzig@latest/dist/leipzig.min.css">

--- a/posts/2022-02-21-ll.html
+++ b/posts/2022-02-21-ll.html
@@ -4,12 +4,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Aryaman Arora</title>
-  <meta name="description" content="Aryaman Arora: NLP Researcher">
-  <meta property="og:title" content="Aryaman Arora">
-  <meta property="og:description" content="NLP Researcher">
-  <link rel="canonical" href="https://aryamanarora.github.io/">
-  <meta name="twitter:card" content="summary">
+  <title> - Aryaman Arora</title>
+  <meta name="description" content="Blog post by Aryaman Arora">
+  <meta property="og:title" content="">
+  <meta property="og:type" content="article">
+<meta property="og:description" content="Blog post by Aryaman Arora">
+  <meta property="og:url" content="https://aryaman.io/posts/2022-02-21-ll.html">
+  <meta property="og:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <meta name="twitter:title" content="">
+  <meta name="twitter:description" content="Blog post by Aryaman Arora">
+  <meta name="twitter:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <link rel="canonical" href="https://aryaman.io/posts/2022-02-21-ll.html">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@aryaman2020">
   <link rel="stylesheet" href="/main.css">
 </head>

--- a/posts/2022-05-03-kk.html
+++ b/posts/2022-05-03-kk.html
@@ -4,12 +4,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Aryaman Arora</title>
-  <meta name="description" content="Aryaman Arora: NLP Researcher">
-  <meta property="og:title" content="Aryaman Arora">
-  <meta property="og:description" content="NLP Researcher">
-  <link rel="canonical" href="https://aryamanarora.github.io/">
-  <meta name="twitter:card" content="summary">
+  <title>The - Aryaman Arora</title>
+  <meta name="description" content="Blog post by Aryaman Arora">
+  <meta property="og:title" content="The">
+  <meta property="og:type" content="article">
+<meta property="og:description" content="Blog post by Aryaman Arora">
+  <meta property="og:url" content="https://aryaman.io/posts/2022-05-03-kk.html">
+  <meta property="og:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <meta name="twitter:title" content="The">
+  <meta name="twitter:description" content="Blog post by Aryaman Arora">
+  <meta name="twitter:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <link rel="canonical" href="https://aryaman.io/posts/2022-05-03-kk.html">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@aryaman2020">
   <link rel="stylesheet" href="/main.css">
 </head>

--- a/posts/2022-05-23-tam.html
+++ b/posts/2022-05-23-tam.html
@@ -4,12 +4,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Aryaman Arora</title>
-  <meta name="description" content="Aryaman Arora: NLP Researcher">
-  <meta property="og:title" content="Aryaman Arora">
-  <meta property="og:description" content="NLP Researcher">
-  <link rel="canonical" href="https://aryamanarora.github.io/">
-  <meta name="twitter:card" content="summary">
+  <title>Secret verb forms in Hindi - Aryaman Arora</title>
+  <meta name="description" content="Blog post by Aryaman Arora">
+  <meta property="og:title" content="Secret verb forms in Hindi">
+  <meta property="og:type" content="article">
+<meta property="og:description" content="Blog post by Aryaman Arora">
+  <meta property="og:url" content="https://aryaman.io/posts/2022-05-23-tam.html">
+  <meta property="og:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <meta name="twitter:title" content="Secret verb forms in Hindi">
+  <meta name="twitter:description" content="Blog post by Aryaman Arora">
+  <meta name="twitter:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <link rel="canonical" href="https://aryaman.io/posts/2022-05-23-tam.html">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@aryaman2020">
   <link rel="stylesheet" href="/main.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leipzig@latest/dist/leipzig.min.css">

--- a/posts/2022-06-21-kitaev.html
+++ b/posts/2022-06-21-kitaev.html
@@ -4,12 +4,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Aryaman Arora</title>
-  <meta name="description" content="Aryaman Arora: NLP Researcher">
-  <meta property="og:title" content="Aryaman Arora">
-  <meta property="og:description" content="NLP Researcher">
-  <link rel="canonical" href="https://aryamanarora.github.io/">
-  <meta name="twitter:card" content="summary">
+  <title>A machine-learned syntactic tagset? - Aryaman Arora</title>
+  <meta name="description" content="Blog post by Aryaman Arora">
+  <meta property="og:title" content="A machine-learned syntactic tagset?">
+  <meta property="og:type" content="article">
+<meta property="og:description" content="Blog post by Aryaman Arora">
+  <meta property="og:url" content="https://aryaman.io/posts/2022-06-21-kitaev.html">
+  <meta property="og:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <meta name="twitter:title" content="A machine-learned syntactic tagset?">
+  <meta name="twitter:description" content="Blog post by Aryaman Arora">
+  <meta name="twitter:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <link rel="canonical" href="https://aryaman.io/posts/2022-06-21-kitaev.html">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@aryaman2020">
   <link rel="stylesheet" href="/main.css">
 </head>

--- a/posts/2022-08-04-naacl.html
+++ b/posts/2022-08-04-naacl.html
@@ -4,12 +4,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Aryaman Arora</title>
-  <meta name="description" content="Aryaman Arora: NLP Researcher">
-  <meta property="og:title" content="Aryaman Arora">
-  <meta property="og:description" content="NLP Researcher">
-  <link rel="canonical" href="https://aryamanarora.github.io/">
-  <meta name="twitter:card" content="summary">
+  <title>NAACL 2022 - Aryaman Arora</title>
+  <meta name="description" content="Blog post by Aryaman Arora">
+  <meta property="og:title" content="NAACL 2022">
+  <meta property="og:type" content="article">
+<meta property="og:description" content="Blog post by Aryaman Arora">
+  <meta property="og:url" content="https://aryaman.io/posts/2022-08-04-naacl.html">
+  <meta property="og:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <meta name="twitter:title" content="NAACL 2022">
+  <meta name="twitter:description" content="Blog post by Aryaman Arora">
+  <meta name="twitter:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <link rel="canonical" href="https://aryaman.io/posts/2022-08-04-naacl.html">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@aryaman2020">
   <link rel="stylesheet" href="/main.css">
 </head>

--- a/posts/2022-10-08-ccg.html
+++ b/posts/2022-10-08-ccg.html
@@ -4,12 +4,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Aryaman Arora</title>
-  <meta name="description" content="Aryaman Arora: NLP Researcher">
-  <meta property="og:title" content="Aryaman Arora">
-  <meta property="og:description" content="NLP Researcher">
-  <link rel="canonical" href="https://aryamanarora.github.io/">
-  <meta name="twitter:card" content="summary">
+  <title>Some CCG derivations in Hindi - Aryaman Arora</title>
+  <meta name="description" content="Blog post by Aryaman Arora">
+  <meta property="og:title" content="Some CCG derivations in Hindi">
+  <meta property="og:type" content="article">
+<meta property="og:description" content="Blog post by Aryaman Arora">
+  <meta property="og:url" content="https://aryaman.io/posts/2022-10-08-ccg.html">
+  <meta property="og:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <meta name="twitter:title" content="Some CCG derivations in Hindi">
+  <meta name="twitter:description" content="Blog post by Aryaman Arora">
+  <meta name="twitter:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <link rel="canonical" href="https://aryaman.io/posts/2022-10-08-ccg.html">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@aryaman2020">
   <link rel="stylesheet" href="/main.css">
 </head>

--- a/posts/2022-12-24-transformers.html
+++ b/posts/2022-12-24-transformers.html
@@ -4,12 +4,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Aryaman Arora</title>
-  <meta name="description" content="Aryaman Arora: NLP Researcher">
-  <meta property="og:title" content="Aryaman Arora">
-  <meta property="og:description" content="NLP Researcher">
-  <link rel="canonical" href="https://aryamanarora.github.io/">
-  <meta name="twitter:card" content="summary">
+  <title>Some intuitions about transformers - Aryaman Arora</title>
+  <meta name="description" content="Blog post by Aryaman Arora">
+  <meta property="og:title" content="Some intuitions about transformers">
+  <meta property="og:type" content="article">
+<meta property="og:description" content="Blog post by Aryaman Arora">
+  <meta property="og:url" content="https://aryaman.io/posts/2022-12-24-transformers.html">
+  <meta property="og:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <meta name="twitter:title" content="Some intuitions about transformers">
+  <meta name="twitter:description" content="Blog post by Aryaman Arora">
+  <meta name="twitter:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <link rel="canonical" href="https://aryaman.io/posts/2022-12-24-transformers.html">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@aryaman2020">
   <link rel="stylesheet" href="/main.css">
 </head>

--- a/posts/2023-03-28-research.html
+++ b/posts/2023-03-28-research.html
@@ -4,12 +4,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Aryaman Arora</title>
-  <meta name="description" content="Aryaman Arora: NLP Researcher">
-  <meta property="og:title" content="Aryaman Arora">
-  <meta property="og:description" content="NLP Researcher">
-  <link rel="canonical" href="https://aryamanarora.github.io/">
-  <meta name="twitter:card" content="summary">
+  <title>Me and Research - Aryaman Arora</title>
+  <meta name="description" content="Blog post by Aryaman Arora">
+  <meta property="og:title" content="Me and Research">
+  <meta property="og:type" content="article">
+<meta property="og:description" content="Blog post by Aryaman Arora">
+  <meta property="og:url" content="https://aryaman.io/posts/2023-03-28-research.html">
+  <meta property="og:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <meta name="twitter:title" content="Me and Research">
+  <meta name="twitter:description" content="Blog post by Aryaman Arora">
+  <meta name="twitter:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <link rel="canonical" href="https://aryaman.io/posts/2023-03-28-research.html">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@aryaman2020">
   <link rel="stylesheet" href="/main.css">
 </head>

--- a/posts/2023-08-10-causality.html
+++ b/posts/2023-08-10-causality.html
@@ -4,12 +4,18 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Aryaman Arora</title>
-  <meta name="description" content="Aryaman Arora: NLP Researcher">
-  <meta property="og:title" content="Aryaman Arora">
-  <meta property="og:description" content="NLP Researcher">
-  <link rel="canonical" href="https://aryamanarora.github.io/">
-  <meta name="twitter:card" content="summary">
+  <title>The Hittite problem - Aryaman Arora</title>
+  <meta name="description" content="Blog post by Aryaman Arora">
+  <meta property="og:title" content="The Hittite problem">
+  <meta property="og:type" content="article">
+<meta property="og:description" content="Blog post by Aryaman Arora">
+  <meta property="og:url" content="https://aryaman.io/posts/2023-08-10-causality.html">
+  <meta property="og:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <meta name="twitter:title" content="The Hittite problem">
+  <meta name="twitter:description" content="Blog post by Aryaman Arora">
+  <meta name="twitter:image" content="https://aryaman.io/static/img/aryaman.jpg">
+  <link rel="canonical" href="https://aryaman.io/posts/2023-08-10-causality.html">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@aryaman2020">
   <link rel="stylesheet" href="/main.css">
 </head>


### PR DESCRIPTION
## Summary
- update all blog posts with Open Graph and Twitter card metadata for better social sharing

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684121e1833c8324bf9f3f3b8dab453c