### PR TITLE
Add 2026-02-01 interpretability post to blog list

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -18,6 +18,7 @@
   <p style="font-size: 24px; font-weight: 600;"><a href="index.html">Aryaman Arora</a> » Blog</p>
   
   <ul>
+    <li>2026-02-01: <a href="posts/2026-02-01-interp.html">Reorient interpretability towards improving the model training process</a></li>
     <li>2023-08-10: <a href="posts/2023-08-10-causality.html">The Hittite problem</a></li>
     <li>2023-03-28: <a href="posts/2023-03-28-research.html">Me and Research</a></li>
     <li>2022-12-24: <a href="posts/2022-12-24-transformers.html">Some intuitions about transformers</a></li>


### PR DESCRIPTION
### Motivation
- Add the newly published 2026-02-01 blog post to the site's Blog index so visitors can access the post from the listing.

### Description
- Inserted a new list item in `blog.html` linking to `posts/2026-02-01-interp.html` with the title "Reorient interpretability towards improving the model training process".

### Testing
- Started a local HTTP server and captured a full-page screenshot of `blog.html` which shows the new entry, and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983f77f82e88324a5d492411cdb4a11)