### PR TITLE
Update circuits paper link to arXiv and year to 2026

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,9 +50,9 @@
   </p>
 
   <p style="margin-top: 3em;"><strong>Greatest Hits</strong> <a href="papers.html"><em><strong>[» more papers]</strong></em></a></p>
-    <p><a href="https://transluce.org/neuron-circuits">Language model circuits are sparse in the neuron basis</a><br>
+    <p><a href="https://arxiv.org/abs/2601.22594">Language model circuits are sparse in the neuron basis</a><br>
       <span class="authors"><strong>Aryaman Arora</strong>*, Zhengxuan Wu*, Jacob Steinhardt, Sarah Schwettmann<br>
-      Transluce Blog, 2025</span>
+      arXiv:2601.22594, 2026</span>
     </p>
     <p><a href="https://arxiv.org/abs/2505.15105">Mechanistic evaluation of Transformers and state space models</a><br>
       <span class="authors"><strong>Aryaman Arora</strong>, Neil Rathi, Nikil Roashan Selvam, Róbert Csórdas, Dan Jurafsky, Christopher Potts<br>

--- a/papers.html
+++ b/papers.html
@@ -19,12 +19,14 @@
   
   <p>These are all of my publications. I also like to keep track of and read <a href="/acks.html">papers I'm acknowledged in</a>.</p>
 
-  <h2>2025</h2>
+  <h2>2026</h2>
 
   <p>Language model circuits are sparse in the neuron basis<br>
     <span class="authors"><strong>Aryaman Arora</strong>*, Zhengxuan Wu*, Jacob Steinhardt, Sarah Schwettmann<br>
-    Transluce Blog, 2025 <a href="https://transluce.org/neuron-circuits">[blogpost]</a></span>
+    arXiv:2601.22594, 2026 <a href="https://arxiv.org/abs/2601.22594">[paper]</a> <a href="https://transluce.org/neuron-circuits">[blogpost]</a></span>
   </p>
+
+  <h2>2025</h2>
 
   <p>Mechanistic evaluation of Transformers and state space models<br>
     <span class="authors"><strong>Aryaman Arora</strong>, Neil Rathi, Nikil Roashan Selvam, Róbert Csórdas, Dan Jurafsky, Christopher Potts<br>


### PR DESCRIPTION
### Motivation
- Ensure the "Language model circuits are sparse in the neuron basis" entry points to the official arXiv version `https://arxiv.org/abs/2601.22594` rather than the blogpost as the primary reference.
- Reflect the arXiv publication year `2026` on both the homepage and the publications page while retaining the existing blogpost as a secondary link.

### Description
- Updated `index.html` to replace the blog URL with `https://arxiv.org/abs/2601.22594` and change the displayed year to `2026` for the Greatest Hits entry.
- Updated `papers.html` to add a new `2026` heading and move the circuits entry under it with the primary link `https://arxiv.org/abs/2601.22594` and the blogpost `https://transluce.org/neuron-circuits` preserved as a secondary link.
- Inserted a `2025` heading below so the other 2025 publications remain correctly grouped.

### Testing
- Ran targeted searches with `rg` to confirm the presence of `2601.22594` and that the updated links and year appear in `index.html` and `papers.html`, which succeeded.
- Inspected the diffs with `git diff` to verify the exact edits to `index.html` and `papers.html`, which matched the intended changes.
- Generated a screenshot of `papers.html` using a Playwright Firefox script to visually validate the page, which succeeded, while a Chromium run failed due to a container browser crash.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990629ac8bc8324ba85ebf6b7e519b5)