### PR TITLE
Update student recruitment status

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
   
   <p>I completed my B.S. in Computer Science and Linguistics at Georgetown University, where I worked with <a href="https://people.cs.georgetown.edu/nschneid/">Nathan Schneider</a> on computational linguistics. I interned at ETH Zürich with <a href="https://rycolab.io/authors/ryan/">Ryan Cotterell</a> working on information theory, as well as at Apple and Redwood Research.</p>
 
-  <p><strong>I am currently recruiting students to work on interpretability. <a href="recruiting.html">[» more info]</a></strong></p>
+  <p><strong>I am not currently taking students.</strong></p>
   
   <p style="margin-top: 3em;"><strong>Contact</strong></p>
   <p style="margin-bottom: 3em;">


### PR DESCRIPTION
## Summary
Updated the recruitment status on the homepage to reflect that the author is no longer accepting new students.

## Changes
- Replaced the active student recruitment message with a clear statement that no new students are being taken
- Removed the link to the recruiting information page as it is no longer applicable

## Details
The change simplifies the message from "I am currently recruiting students to work on interpretability. [» more info]" to "I am not currently taking students." This provides a direct and unambiguous statement to visitors about the current availability for student supervision.

https://claude.ai/code/session_01FtQhbfhXDNMPSjTXjib48p